### PR TITLE
Scale EXPLAIN_INFERENCES_TO_TRACE_CHUNK memory by TTL graph size

### DIFF
--- a/oxo2-dataload/nextflow/nextflow.config
+++ b/oxo2-dataload/nextflow/nextflow.config
@@ -131,10 +131,18 @@ profiles {
             withName: 'EXPLAIN_INFERENCES_TO_TRACE_CHUNK' {
                 cpus = 1
                 memory = {
-                    // Same predictive formula, scaled to the chunk's trace input. Floor
-                    // at 4 GB so SLURM accounting keeps small chunks cheap to schedule;
-                    // VTO chunks empirically peaked at ~1.6 GB.
-                    def predicted = chunk_file.size() * 120L
+                    // Heap is dominated by the asserted + inferred TTL graphs nemo loads,
+                    // not the chunk trace input — chunks for a given set all need the same
+                    // heap. INFER on ncbitaxon peaked at 5.4 GB on a 3.4 GB asserted TTL
+                    // (~1.6x file size); EXPLAIN holds asserted + inferred plus chunk state,
+                    // so ~3x of the combined file size covers it with headroom. Small sets
+                    // stay at the 4 GB floor (SLURM accounting cheap); ncbitaxon (3.4 GB +
+                    // 918 MB ≈ 4.3 GB combined) → ~13 GB, fixing the 466-chunk OOM cascade.
+                    def asserted = file("${params.asserted_mappings_dir}/${baseName}.ttl")
+                    def inferred = file("${params.inferred_mappings_dir}/${baseName}.ttl")
+                    def assertedSize = asserted.exists() ? asserted.size() : 0L
+                    def inferredSize = inferred.exists() ? inferred.size() : 0L
+                    def predicted = (assertedSize + inferredSize) * 3L + chunk_file.size() * 120L
                     def floor = 4L * 1024L * 1024L * 1024L
                     Math.max(predicted, floor) as nextflow.util.MemoryUnit
                 }


### PR DESCRIPTION
## Summary
- Fixes 466-chunk OOM cascade on ncbitaxon during `inferAndExplainMappings` on HPC: every ncbitaxon chunk hit exit 137 because the previous predictor (`chunk_file.size() * 120`) always fell below the 4 GB floor.
- Heap is dominated by the asserted + inferred TTL graphs nemo loads, not the chunk size, so scale memory by ~3x of the combined TTL file size. 4 GB floor preserved for small sets.
- For ncbitaxon (3.4 GB asserted + 918 MB inferred ≈ 4.3 GB combined) this yields ~13 GB; everything else stays at 4 GB.

## Test plan
- [ ] Re-run `loadData.hpc` and confirm ncbitaxon EXPLAIN chunks complete (no exit 137).
- [ ] Spot-check `inferAndExplainMappings-trace.txt` for ncbitaxon chunk peak_rss vs allocated memory to validate the 3x ratio.
- [ ] Confirm small sets (e.g. afpo, ado) still get 4 GB allocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)