### PR TITLE
Use new File() instead of file() in memory directive closure.

### DIFF
--- a/oxo2-dataload/nextflow/nextflow.config
+++ b/oxo2-dataload/nextflow/nextflow.config
@@ -138,10 +138,10 @@ profiles {
                     // so ~3x of the combined file size covers it with headroom. Small sets
                     // stay at the 4 GB floor (SLURM accounting cheap); ncbitaxon (3.4 GB +
                     // 918 MB ≈ 4.3 GB combined) → ~13 GB, fixing the 466-chunk OOM cascade.
-                    def asserted = file("${params.asserted_mappings_dir}/${baseName}.ttl")
-                    def inferred = file("${params.inferred_mappings_dir}/${baseName}.ttl")
-                    def assertedSize = asserted.exists() ? asserted.size() : 0L
-                    def inferredSize = inferred.exists() ? inferred.size() : 0L
+                    def asserted = new File("${params.asserted_mappings_dir}/${baseName}.ttl")
+                    def inferred = new File("${params.inferred_mappings_dir}/${baseName}.ttl")
+                    def assertedSize = asserted.exists() ? asserted.length() : 0L
+                    def inferredSize = inferred.exists() ? inferred.length() : 0L
                     def predicted = (assertedSize + inferredSize) * 3L + chunk_file.size() * 120L
                     def floor = 4L * 1024L * 1024L * 1024L
                     Math.max(predicted, floor) as nextflow.util.MemoryUnit


### PR DESCRIPTION
The file() helper isn't exposed in nextflow.config process directive closures (only in script/workflow scope), causing
ScriptBinding.file() with no args at task scheduling. Plain java.io.File works the same for local-filesystem TTLs on SLURM.