### PR TITLE
Speed up and harden EXPLANATIONS_TO_JSON for large inference chains.

### DIFF
--- a/oxo2-dataload/oxo2-json2inferences/explanations2json.nf
+++ b/oxo2-dataload/oxo2-json2inferences/explanations2json.nf
@@ -64,10 +64,16 @@ process EXPLANATIONS_TO_JSON {
     def output_file = "${base}-explained.json"
     def mapping_set_output_file = "${base}-mappingSet.json"
     def solr_url = params.solr_url ?: 'http://localhost:8983/solr'
+    // Size the JVM heap from the task allocation. Without -Xmx, OpenJDK falls
+    // back to ~25% of host RAM, which on large SLURM nodes is far below the
+    // configured task.memory and OOMs on big inputs (e.g. snomed at 64 GB
+    // allocated, ~31 GB default heap). 80% of allocation leaves headroom for
+    // metaspace, direct buffers, and native code.
+    def heap_mb = (task.memory.toMega() * 0.8) as long
     """
     export SOLR_URL="${solr_url}"
     export no_proxy="localhost,127.0.0.1,\$(hostname),${solr_url.replaceAll('https?://','').replaceAll('/.*','').replaceAll(':.*','')}"
-    export JAVA_OPTS="\${JAVA_OPTS:-} -Dhttp.nonProxyHosts=localhost|127.0.0.1|${solr_url.replaceAll('https?://','').replaceAll('/.*','').replaceAll(':.*','')}"
+    export JAVA_OPTS="-Xmx${heap_mb}m \${JAVA_OPTS:-} -Dhttp.nonProxyHosts=localhost|127.0.0.1|${solr_url.replaceAll('https?://','').replaceAll('/.*','').replaceAll(':.*','')}"
     "${effective_script_dir}/explanations2jsonNextflow.sh" "${input_file}" "${output_file}" "${mapping_set_output_file}" "${source_mapping_set_id}"
 
     # Remove if empty

--- a/oxo2-dataload/oxo2-json2inferences/src/main/java/uk/ac/ebi/spot/oxo/inferences/nemo/ExplainInferredMappings.java
+++ b/oxo2-dataload/oxo2-json2inferences/src/main/java/uk/ac/ebi/spot/oxo/inferences/nemo/ExplainInferredMappings.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.spot.oxo.inferences.nemo;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -130,14 +131,12 @@ public class ExplainInferredMappings {
                 logger.info("Generated {} inferred mappings", inferredMappings.size());
             }
 
-            logger.info("Creating mappings...");
-            List<Mapping> mappings = createMappings(inferredMappings, solrClient, sourceMappingSetId);
-            logger.info("Created {} mappings", mappings.size());
+            logger.info("Creating mappings and streaming to file: {}", outputFilePath);
+            long writtenCount = streamMappingsToJson(inferredMappings, solrClient, sourceMappingSetId,
+                    outputFilePath);
+            logger.info("Wrote {} mappings", writtenCount);
 
-            logger.info("Writing mappings to file: {}", outputFilePath);
-            writeMappingsAsJson(mappings, outputFilePath);
-
-            if (!mappings.isEmpty()) {
+            if (writtenCount > 0) {
                 logger.info("Writing inferred MappingSet metadata to file: {}", mappingSetOutputFilePath);
                 writeInferredMappingSet(sourceMappingSetId, mappingSetOutputFilePath);
             } else {
@@ -255,16 +254,14 @@ public class ExplainInferredMappings {
                         logger.info("Generated {} inferred mappings", inferredMappings.size());
                     }
 
-                    logger.info("Creating mappings...");
-                    List<Mapping> mappings = createMappings(inferredMappings, solrClient, sourceMappingSetId);
-                    logger.info("Created {} mappings", mappings.size());
-
                     String outputFilePath = new File(outputDir, baseName + ".json").getAbsolutePath();
 
-                    logger.info("Writing mappings to file: {}", outputFilePath);
-                    writeMappingsAsJson(mappings, outputFilePath);
+                    logger.info("Creating mappings and streaming to file: {}", outputFilePath);
+                    long writtenCount = streamMappingsToJson(inferredMappings, solrClient,
+                            sourceMappingSetId, outputFilePath);
+                    logger.info("Wrote {} mappings", writtenCount);
 
-                    if (!mappings.isEmpty()) {
+                    if (writtenCount > 0) {
                         String mappingSetBaseName = baseName.endsWith(CHAIN_FILE_SUFFIX)
                                 ? baseName.substring(0, baseName.length() - CHAIN_FILE_SUFFIX.length())
                                 : baseName;
@@ -371,11 +368,34 @@ public class ExplainInferredMappings {
         logger.info("Inferred MappingSet successfully written to {} ({} bytes)", outputFilePath, file.length());
     }
 
-    public static void writeMappingsAsJson(List<Mapping> mappings, String outputFile) throws IOException {
-        if (mappings == null || mappings.isEmpty()) {
-            logger.warn("No mappings to write to file");
-            return;
+    /**
+     * Build {@link Mapping} records from the inferred-mapping DAG and stream
+     * them straight to {@code outputFilePath} as a JSON array. Each Mapping is
+     * serialized and dropped within its own loop iteration, so the working set
+     * never holds the full result list. The output file is opened lazily on
+     * the first emitted mapping; if no mapping survives the skip filters, no
+     * file is written (matching the previous {@code writeMappingsAsJson}
+     * behaviour and the downstream {@code [ ! -s file ]} cleanup in the .nf).
+     *
+     * @return the number of {@link Mapping} records written.
+     */
+    public static long streamMappingsToJson(Set<InferredMapping> inferredMappings,
+                                             DataloadSolr solrClient,
+                                             String sourceMappingSetId,
+                                             String outputFilePath) throws IOException {
+        if (inferredMappings == null || inferredMappings.isEmpty()) {
+            logger.warn("No inferred mappings to process");
+            return 0;
         }
+
+        String inferredMappingSetId = OXOInferenceConstants.inferredMappingSetIdFor(sourceMappingSetId);
+
+        // Per-run memos for the two recursive walks over the InferredMapping DAG.
+        // NemoHelper.determineInferencesLeadingToConclusion guarantees one object
+        // per distinct conclusion string, so identity-keyed maps are correct and
+        // cheaper than equals-keyed (InferredMapping.hashCode hashes 3 IRI Strings).
+        IdentityHashMap<InferredMapping, List<InferredMapping>> assertedMemo = new IdentityHashMap<>();
+        IdentityHashMap<InferredMapping, Integer> lengthMemo = new IdentityHashMap<>();
 
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new Jdk8Module());
@@ -384,100 +404,115 @@ public class ExplainInferredMappings {
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-        File file = new File(outputFile);
+        File outputFile = new File(outputFilePath);
+        SequenceWriter seqWriter = null;
+        long written = 0;
+        int processed = 0;
+        boolean closedCleanly = false;
         try {
-            objectMapper.writeValue(file, mappings);
-            logger.info("Mappings successfully written to {} ({} bytes)", outputFile, file.length());
-        } catch (IOException e) {
-            logger.error("Error writing mappings to JSON file = {}, {}", file.getName(), e.getMessage());
-            throw e;
-        }
-    }
+            for (InferredMapping inferredMapping : inferredMappings) {
+                try {
+                    if (inferredMapping.getSubjectIRI() == null || inferredMapping.getPredicateIRI() == null ||
+                        inferredMapping.getObjectIRI() == null) {
+                        logger.warn("Skipping mapping with null IRI values: {}", inferredMapping);
+                        continue;
+                    }
+                    if (inferredMapping.isMappingToSelf()) {
+                        logger.debug("Skipping self-mapping: {}", inferredMapping);
+                        continue;
+                    }
+                    if (inferredMapping.getChainRuleApplications().isPresent() &&
+                        inferredMapping.getChainRuleApplications().get().getPremises().size() <= 1) {
+                        logger.debug("Skipping mapping with no premises - hence it is an asserted mapping: {}", inferredMapping);
+                        continue;
+                    }
 
-    public static List<Mapping> createMappings(Set<InferredMapping> inferredMappings,
-                                               DataloadSolr solrClient,
-                                               String sourceMappingSetId) {
-        if (inferredMappings == null || inferredMappings.isEmpty()) {
-            logger.warn("No inferred mappings to process");
-            return new ArrayList<>();
-        }
+                    EntityDetails subjectDetails = solrClient.queryEntityDetailsForIRI(SUBJECT_IRI,
+                            inferredMapping.getSubjectIRI().asStringIRI(), SUBJECT_ID, SUBJECT_LABEL);
+                    String predicateIri = inferredMapping.getPredicateIRI().asStringIRI();
+                    Optional<String> predicateCurie = PrefixMap.toCurie(predicateIri);
+                    String predicateId;
+                    String predicateLabel;
+                    if (predicateCurie.isPresent()) {
+                        predicateId = predicateCurie.get();
+                        predicateLabel = "";
+                    } else {
+                        EntityDetails predicateDetails = solrClient.queryEntityDetailsForIRI(PREDICATE_IRI,
+                                predicateIri, PREDICATE_ID, PREDICATE_LABEL);
+                        predicateId = (predicateDetails != null && predicateDetails.getCurie() != null) ?
+                                predicateDetails.getCurie() : "";
+                        predicateLabel = (predicateDetails != null && predicateDetails.getLabel() != null) ?
+                                predicateDetails.getLabel() : "";
+                    }
+                    EntityDetails objectDetails = solrClient.queryEntityDetailsForIRI(OBJECT_IRI,
+                            inferredMapping.getObjectIRI().asStringIRI(), OBJECT_ID, OBJECT_LABEL);
 
-        String inferredMappingSetId = OXOInferenceConstants.inferredMappingSetIdFor(sourceMappingSetId);
-        List<Mapping> mappings = new ArrayList<>(inferredMappings.size());
-        int count = 0;
+                    Mapping mapping = new Mapping.Builder()
+                        .subjectIRI(inferredMapping.getSubjectIRI().asStringIRI())
+                        .subjectId((subjectDetails != null && subjectDetails.getCurie() != null) ?
+                                subjectDetails.getCurie() : "")
+                        .subjectLabel((subjectDetails != null && subjectDetails.getLabel() != null) ?
+                                subjectDetails.getLabel() : "")
+                        .predicateIRI(predicateIri)
+                        .predicateId(predicateId)
+                        .predicateLabel(predicateLabel)
+                        .objectIRI(inferredMapping.getObjectIRI().asStringIRI())
+                        .objectId((objectDetails != null && objectDetails.getCurie() != null) ?
+                                objectDetails.getCurie() : "")
+                        .objectLabel((objectDetails != null && objectDetails.getLabel() != null) ?
+                                objectDetails.getLabel() : "")
+                        .mappingJustification(OXOInferenceConstants.OXO_MAPPING_JUSTIFICATION)
+                        .mappingTool(OXOInferenceConstants.OXO_MAPPING_TOOL)
+                        .explanation(inferredMapping)
+                        .assertedMappings(determineAssertedMappingsForExplanation(inferredMapping, assertedMemo))
+                        .explanationLength(explanationLength(inferredMapping, lengthMemo))
+                        .distance(calculateMappingDistance(inferredMapping))
+                        .mappingSetId(inferredMappingSetId)
+                        .build();
 
-        for (InferredMapping inferredMapping : inferredMappings) {
-            try {
-                if (inferredMapping.getSubjectIRI() == null || inferredMapping.getPredicateIRI() == null ||
-                    inferredMapping.getObjectIRI() == null) {
-                    logger.warn("Skipping mapping with null IRI values: {}", inferredMapping);
-                    continue;
+                    if (seqWriter == null) {
+                        seqWriter = objectMapper.writer().writeValuesAsArray(outputFile);
+                    }
+                    seqWriter.write(mapping);
+                    written++;
+
+                    processed++;
+                    if (processed % 1000 == 0) {
+                        logger.info("Processed {} mappings", processed);
+                    }
+                } catch (Exception e) {
+                    logger.error("Error creating mapping for: {}", inferredMapping, e);
                 }
-                if (inferredMapping.isMappingToSelf()) {
-                    logger.debug("Skipping self-mapping: {}", inferredMapping);
-                    continue;
-                }
-                if (inferredMapping.getChainRuleApplications().isPresent() &&
-                    inferredMapping.getChainRuleApplications().get().getPremises().size() <= 1) {
-                    logger.debug("Skipping mapping with no premises - hence it is an asserted mapping: {}", inferredMapping);
-                    continue;
-                }
-
-                EntityDetails subjectDetails = solrClient.queryEntityDetailsForIRI(SUBJECT_IRI,
-                        inferredMapping.getSubjectIRI().asStringIRI(), SUBJECT_ID, SUBJECT_LABEL);
-                String predicateIri = inferredMapping.getPredicateIRI().asStringIRI();
-                Optional<String> predicateCurie = PrefixMap.toCurie(predicateIri);
-                String predicateId;
-                String predicateLabel;
-                if (predicateCurie.isPresent()) {
-                    predicateId = predicateCurie.get();
-                    predicateLabel = "";
-                } else {
-                    EntityDetails predicateDetails = solrClient.queryEntityDetailsForIRI(PREDICATE_IRI,
-                            predicateIri, PREDICATE_ID, PREDICATE_LABEL);
-                    predicateId = (predicateDetails != null && predicateDetails.getCurie() != null) ?
-                            predicateDetails.getCurie() : "";
-                    predicateLabel = (predicateDetails != null && predicateDetails.getLabel() != null) ?
-                            predicateDetails.getLabel() : "";
-                }
-                EntityDetails objectDetails = solrClient.queryEntityDetailsForIRI(OBJECT_IRI,
-                        inferredMapping.getObjectIRI().asStringIRI(), OBJECT_ID, OBJECT_LABEL);
-
-                Mapping mapping = new Mapping.Builder()
-                    .subjectIRI(inferredMapping.getSubjectIRI().asStringIRI())
-                    .subjectId((subjectDetails != null && subjectDetails.getCurie() != null) ?
-                            subjectDetails.getCurie() : "")
-                    .subjectLabel((subjectDetails != null && subjectDetails.getLabel() != null) ?
-                            subjectDetails.getLabel() : "")
-                    .predicateIRI(predicateIri)
-                    .predicateId(predicateId)
-                    .predicateLabel(predicateLabel)
-                    .objectIRI(inferredMapping.getObjectIRI().asStringIRI())
-                    .objectId((objectDetails != null && objectDetails.getCurie() != null) ?
-                            objectDetails.getCurie() : "")
-                    .objectLabel((objectDetails != null && objectDetails.getLabel() != null) ?
-                            objectDetails.getLabel() : "")
-                    .mappingJustification(OXOInferenceConstants.OXO_MAPPING_JUSTIFICATION)
-                    .mappingTool(OXOInferenceConstants.OXO_MAPPING_TOOL)
-                    .explanation(inferredMapping)
-                    .assertedMappings(determineAssertedMappingsForExplanation(inferredMapping))
-                    .explanationLength(determineExplanationLength(inferredMapping, 0))
-                    .distance(calculateMappingDistance(inferredMapping))
-                    .mappingSetId(inferredMappingSetId)
-                    .build();
-                mappings.add(mapping);
-
-                count++;
-                if (count % 1000 == 0) {
-                    logger.info("Processed {} mappings", count);
-                }
-            } catch (Exception e) {
-                logger.error("Error creating mapping for: {}", inferredMapping, e);
             }
-
+            if (seqWriter != null) {
+                seqWriter.close();
+                seqWriter = null;
+            }
+            closedCleanly = true;
+        } finally {
+            if (seqWriter != null) {
+                try { seqWriter.close(); } catch (Exception ignored) { /* swallow during cleanup */ }
+            }
+            // On any failure that left a partial JSON on disk, remove it so the
+            // .nf "[ ! -s file ]" cleanup doesn't preserve a corrupt artefact
+            // that downstream Solr indexing would later fail to parse.
+            if (!closedCleanly && written > 0 && outputFile.exists()) {
+                if (!outputFile.delete()) {
+                    logger.warn("Failed to delete partial output file after error: {}", outputFilePath);
+                }
+            }
         }
 
-        return mappings;
+        logger.info("Walk memos: {} top-level mappings, {} memoized assertedMappings entries, {} memoized explanationLength entries",
+                inferredMappings.size(), assertedMemo.size(), lengthMemo.size());
+
+        if (written > 0) {
+            logger.info("Mappings successfully streamed to {} ({} mappings, {} bytes)",
+                    outputFilePath, written, outputFile.length());
+        } else {
+            logger.warn("No mappings written to file");
+        }
+        return written;
     }
 
     /**
@@ -485,16 +520,21 @@ public class ExplainInferredMappings {
      * However, it is possible that the same mapping is asserted in multiple mapping sets. Hence, this method retrieves
      * all asserted mappings. This can be useful for users who need to debug incorrect derived mappings.
      *
-     * @param explanation
-     * @return
+     * <p>Memoized: shared sub-chains in the DAG (created via NemoHelper's
+     * conclusion-keyed memo) are walked once, not once per parent.
      */
-    private static List<InferredMapping> determineAssertedMappingsForExplanation(
-            InferredMapping explanation) {
+    static List<InferredMapping> determineAssertedMappingsForExplanation(
+            InferredMapping explanation,
+            IdentityHashMap<InferredMapping, List<InferredMapping>> memo) {
+        List<InferredMapping> cached = memo.get(explanation);
+        if (cached != null) return cached;
 
         List<InferredMapping> assertedMappings = new ArrayList<>();
 
-        if (explanation.getChainRuleApplications().isEmpty())
+        if (explanation.getChainRuleApplications().isEmpty()) {
+            memo.put(explanation, assertedMappings);
             return assertedMappings;
+        }
 
         InferredMapping.ChainRuleApplications chainRuleApplications = explanation.getChainRuleApplications().get();
 
@@ -502,25 +542,35 @@ public class ExplainInferredMappings {
                 chainRuleApplications.getChainRule().get().equals(ChainRulesEnum.ASSERTED))
             assertedMappings.add(explanation);
 
-        explanation.getChainRuleApplications().get().getPremises().forEach(premise -> {
-            List<InferredMapping> assertedMappingsToAdd = determineAssertedMappingsForExplanation(premise);
-            assertedMappings.addAll(assertedMappingsToAdd);
-        });
+        for (InferredMapping premise : chainRuleApplications.getPremises()) {
+            assertedMappings.addAll(determineAssertedMappingsForExplanation(premise, memo));
+        }
 
+        memo.put(explanation, assertedMappings);
         return assertedMappings;
     }
 
-    private static int determineExplanationLength(InferredMapping explanation, int startExplanationLength) {
-        int explanationLength = startExplanationLength;
+    /**
+     * Length of the chain rooted at {@code explanation}: 0 for an asserted/leaf
+     * node, otherwise 1 + sum of premise lengths. Memoized so shared sub-chains
+     * are walked once.
+     */
+    static int explanationLength(InferredMapping explanation,
+                                 IdentityHashMap<InferredMapping, Integer> memo) {
+        Integer cached = memo.get(explanation);
+        if (cached != null) return cached;
 
-        if (explanation.getChainRuleApplications().isEmpty())
-            return explanationLength;
-        explanationLength++;
-        for (InferredMapping premise: explanation.getChainRuleApplications().get().getPremises()) {
-            explanationLength = determineExplanationLength(premise, explanationLength);
+        int length;
+        if (explanation.getChainRuleApplications().isEmpty()) {
+            length = 0;
+        } else {
+            length = 1;
+            for (InferredMapping premise : explanation.getChainRuleApplications().get().getPremises()) {
+                length += explanationLength(premise, memo);
+            }
         }
-
-        return explanationLength;
+        memo.put(explanation, length);
+        return length;
     }
 
     private static int calculateMappingDistance(InferredMapping explanation) {

--- a/oxo2-dataload/oxo2-json2inferences/src/test/java/uk/ac/ebi/spot/oxo/inferences/nemo/ExplainInferredMappingsTest.java
+++ b/oxo2-dataload/oxo2-json2inferences/src/test/java/uk/ac/ebi/spot/oxo/inferences/nemo/ExplainInferredMappingsTest.java
@@ -1,0 +1,124 @@
+package uk.ac.ebi.spot.oxo.inferences.nemo;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.spot.oxo.model.sssom.ChainRulesEnum;
+import uk.ac.ebi.spot.oxo.model.sssom.InferredMapping;
+import uk.ac.ebi.spot.oxo.model.sssom.Uri;
+
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ExplainInferredMappingsTest {
+
+    /** Build a leaf node tagged ASSERTED. */
+    private static InferredMapping asserted(String s, String p, String o) {
+        InferredMapping node = new InferredMapping();
+        node.setSubjectIRI(new Uri(s));
+        node.setPredicateIRI(new Uri(p));
+        node.setObjectIRI(new Uri(o));
+        InferredMapping.ChainRuleApplications cra =
+                new InferredMapping.ChainRuleApplications(Optional.of(ChainRulesEnum.ASSERTED));
+        cra.setPremises(List.of());
+        node.setChainRuleApplications(Optional.of(cra));
+        return node;
+    }
+
+    /** Build an inferred node with a chain rule and the given premises. */
+    private static InferredMapping inferred(String s, String p, String o,
+                                             ChainRulesEnum rule,
+                                             InferredMapping... premises) {
+        InferredMapping node = new InferredMapping();
+        node.setSubjectIRI(new Uri(s));
+        node.setPredicateIRI(new Uri(p));
+        node.setObjectIRI(new Uri(o));
+        InferredMapping.ChainRuleApplications cra =
+                new InferredMapping.ChainRuleApplications(Optional.of(rule));
+        cra.setPremises(List.of(premises));
+        node.setChainRuleApplications(Optional.of(cra));
+        return node;
+    }
+
+    @Test
+    void explanationLengthCountsChainNodesIncludingRoot() {
+        InferredMapping leaf = asserted("urn:a", "urn:p", "urn:b");
+        InferredMapping mid = inferred("urn:a", "urn:p", "urn:c", ChainRulesEnum.T1, leaf);
+        InferredMapping root = inferred("urn:a", "urn:p", "urn:d", ChainRulesEnum.T1, mid);
+
+        IdentityHashMap<InferredMapping, Integer> memo = new IdentityHashMap<>();
+
+        // leaf: ASSERTED chain present but with no premises is still a non-empty
+        // chain rule application, so length counts the leaf node itself.
+        assertEquals(1, ExplainInferredMappings.explanationLength(leaf, memo));
+        assertEquals(2, ExplainInferredMappings.explanationLength(mid, memo));
+        assertEquals(3, ExplainInferredMappings.explanationLength(root, memo));
+    }
+
+    @Test
+    void explanationLengthMemoizesSharedSubChain() {
+        // Diamond: root has two parents, both pointing at the same shared leaf.
+        //   root -> leftMid \
+        //                    -> sharedLeaf
+        //   root -> rightMid /
+        InferredMapping sharedLeaf = asserted("urn:s", "urn:p", "urn:o");
+        InferredMapping leftMid = inferred("urn:s", "urn:p", "urn:l",
+                ChainRulesEnum.T1, sharedLeaf);
+        InferredMapping rightMid = inferred("urn:s", "urn:p", "urn:r",
+                ChainRulesEnum.T1, sharedLeaf);
+        InferredMapping root = inferred("urn:s", "urn:p", "urn:root",
+                ChainRulesEnum.T1, leftMid, rightMid);
+
+        IdentityHashMap<InferredMapping, Integer> memo = new IdentityHashMap<>();
+        int rootLen = ExplainInferredMappings.explanationLength(root, memo);
+
+        // root(1) + leftMid(1) + rightMid(1) + sharedLeaf(1) + sharedLeaf(1) = 5
+        assertEquals(5, rootLen);
+        // sharedLeaf walked once even though referenced twice.
+        assertEquals(4, memo.size());
+        assertEquals(1, memo.get(sharedLeaf));
+    }
+
+    @Test
+    void assertedMappingsCollectsAssertedLeavesInTraversalOrder() {
+        InferredMapping leafA = asserted("urn:s", "urn:p", "urn:a");
+        InferredMapping leafB = asserted("urn:s", "urn:p", "urn:b");
+        InferredMapping mid = inferred("urn:s", "urn:p", "urn:m",
+                ChainRulesEnum.T1, leafA, leafB);
+        InferredMapping root = inferred("urn:s", "urn:p", "urn:root",
+                ChainRulesEnum.T1, mid);
+
+        IdentityHashMap<InferredMapping, List<InferredMapping>> memo = new IdentityHashMap<>();
+        List<InferredMapping> result = ExplainInferredMappings
+                .determineAssertedMappingsForExplanation(root, memo);
+
+        assertEquals(List.of(leafA, leafB), result);
+    }
+
+    @Test
+    void assertedMappingsMemoSharesListInstanceForSharedSubChain() {
+        InferredMapping sharedLeaf = asserted("urn:s", "urn:p", "urn:o");
+        InferredMapping leftMid = inferred("urn:s", "urn:p", "urn:l",
+                ChainRulesEnum.T1, sharedLeaf);
+        InferredMapping rightMid = inferred("urn:s", "urn:p", "urn:r",
+                ChainRulesEnum.T1, sharedLeaf);
+        InferredMapping root = inferred("urn:s", "urn:p", "urn:root",
+                ChainRulesEnum.T1, leftMid, rightMid);
+
+        IdentityHashMap<InferredMapping, List<InferredMapping>> memo = new IdentityHashMap<>();
+        List<InferredMapping> rootResult = ExplainInferredMappings
+                .determineAssertedMappingsForExplanation(root, memo);
+
+        // Both diamond legs surface the same asserted leaf, so it appears twice
+        // at the root level — addAll preserves order without dedup, matching the
+        // pre-memoization behaviour.
+        assertEquals(List.of(sharedLeaf, sharedLeaf), rootResult);
+
+        // sharedLeaf cached once and the cached entry is reused (not recomputed)
+        // when leftMid and rightMid pull it in.
+        assertSame(memo.get(leftMid).get(0), memo.get(rightMid).get(0));
+        assertEquals(4, memo.size());
+    }
+}


### PR DESCRIPTION
Snomed (2.1 GB chains JSON, 1.5M+ inferred mappings) was hitting a Java OOM in the create/write phase, with the per-1000-mappings rate falling from ~120/s to ~2/s as the heap filled and GC death-spiraled. Three changes address both the OOM and the slowdown:

- Size -Xmx from task.memory in explanations2json.nf. Without an explicit -Xmx, OpenJDK fell back to ~25% of host RAM (~31 GB on the SLURM node) even though snomed was allocated 64 GB; the JVM OOM'd before reaching half of its allocation.
- Memoize determineAssertedMappingsForExplanation and explanationLength in IdentityHashMaps keyed on InferredMapping. NemoHelper already shares one object per distinct conclusion, so shared sub-chains in the DAG were being re-walked once per parent. With memoization each unique node is walked exactly once.
- Replace createMappings + writeMappingsAsJson with streamMappingsToJson, which writes each Mapping straight to a Jackson SequenceWriter and drops the reference, instead of buffering a List<Mapping> for the whole run. The output file opens lazily so the existing "no mappings -> no file" semantic is preserved, and a partial file is deleted on exception so a corrupt JSON cannot slip past the .nf "[ ! -s file ]" cleanup and break Solr indexing.

Adds JUnit coverage for the two memoized walks (linear chain, diamond DAG, traversal order, shared-list reuse). Streaming behaviour is covered end-to-end via cmp(1) against pre-change output on a small set.