### PR TITLE
chore: collapse dependabot maven directories to root only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,11 @@ updates:
           - "minor"
           - "patch"
 
-  # Maven — root parent pom + 7 module poms
+  # Maven — single scan from the repo root; dependabot walks the parent pom
+  # and every reachable module, opening one PR per dependency that touches
+  # all affected pom.xml files.
   - package-ecosystem: "maven"
-    directories:
-      - "/"
-      - "/oxo2-shared"
-      - "/oxo2-backend"
-      - "/oxo2-dataload"
-      - "/oxo2-dataload/oxo2-downloader"
-      - "/oxo2-dataload/oxo2-sssom2json"
-      - "/oxo2-dataload/oxo2-json2inferences"
-      - "/oxo2-dataload/oxo2-solr-dataload-client"
+    directory: "/"
     schedule:
       interval: "daily"
       time: "07:00"


### PR DESCRIPTION
## Summary
- Replace the 8-entry `directories:` list under `package-ecosystem: maven` with a single `directory: "/"`.
- Fixes the duplicate-PR storm: every major-version bump was producing one umbrella PR (at `/`) plus per-module PRs that touched subsets of the same `pom.xml` files (e.g. Spring Boot 4 #45 vs #46, solrj 10 #26 vs #33/#37/#40/#41, Jena 6 #27 vs #36/#39).
- Dependabot's single-directory maven scan walks the parent pom and every reachable module, so we still get coverage of all 8 poms — just in one PR per dependency.

## Test plan
- [ ] After merge, watch tomorrow's 07:00 Europe/London dependabot run produce only one PR per outstanding dependency (no per-module duplicates).
- [ ] Existing open duplicates are closed separately as part of the broader dependabot triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)