### PR TITLE
feat: group same-SPO mappings into one expandable row in result views

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,13 @@ OxO2 as `ChainRulesEnum` (`RCE`, `T`, `RI`, `RG`, `RCE-N` families) and as Nemo 
 - **Explanation chain** — the full derivation tree for an inferred mapping, recording every chain-rule application back to asserted mappings.
 - **Facts to trace** — the set of inferred mappings whose explanation chains still need to be computed. Produced by the inference stage, 
 consumed by the trace stage. Lives as per-set files split into chunks for parallel tracing (see § Cross-cutting constraints).
+- **Mapping group** — the set of mappings that share the same `subject_id`, `predicate_id`, `predicate_modifier`, and `object_id`: one 
+asserted *meaning* of a triple, collapsed into a single row in the Search and Inferences result views (see § Cross-cutting constraints). 
+Identified by the denormalised `spo_key` field. A relation and its negation (`predicate_modifier = Not`) form **different** groups. 
+_Avoid_: collapsed row, duplicate mappings, SPO group.
+- **Representative mapping** — the member of a **mapping group** shown as its parent row: the highest inference-tier member (`ASSERTED` 
+over `SSSOM_INFERENCE` over `OWL_INFERENCE`, shorter chains first). Its subject/predicate/object are the ones displayed; the remaining 
+members are reached by expanding the row.
 
 ## Module map
 
@@ -98,6 +105,12 @@ builder) and `oxo2-mappings` (`mapping_id` becomes `indexed`).
 `https://www.ebi.ac.uk/oxo2/inferences[/…]` and resolve to an OxO2 mapping-set view. See 
 [ADR-0012](docs/adr/0012-resolvable-inference-set-iris.md). Affects `oxo2-dataload` (set ids), `oxo2-backend` (`GET 
 /api/v2/mapping-sets/by-id?mappingSetId=<IRI>`), and `oxo2-frontend` (`/inferences` route).
+- **Same-SPO mappings are grouped in result views** — the Search and Inferences tables collapse mappings sharing 
+(`subject_id`, `predicate_id`, `predicate_modifier`, `object_id`) into one *mapping group* row, via the denormalised Solr `spo_key` 
+field and Solr result grouping. Grouping is presentation-layer, layered on top of the inference-type filter, and a page counts groups 
+not documents (`group.ngroups`); the Advanced tab stays flat. See [ADR-0013](docs/adr/0013-group-same-spo-mappings-in-result-views.md). 
+Affects `oxo2-dataload` (`spo_key` population + reindex), `oxo2-backend` (grouped query path + `group_members` transport), and 
+`oxo2-frontend` (expandable rows, paging over groups).
 - **Nextflow is the sole dataload execution path** — production dataload runs via `loadData.nextflow` only; per-stage `.sh` 
 scripts are debug-only. See [ADR-0003](docs/adr/0003-nextflow-as-sole-dataload-path.md). Affects `oxo2-dataload`.
 - **OxO2 is backwards compatible with OxO v1** — API surface answers v1's questions even where SSSOM terms are richer. 

--- a/docs/adr/0013-group-same-spo-mappings-in-result-views.md
+++ b/docs/adr/0013-group-same-spo-mappings-in-result-views.md
@@ -1,0 +1,72 @@
+# ADR-0013: Group same-SPO mappings into one row in result views
+
+- **Status**: Accepted
+- **Date**: 2026-06-08
+
+## Context
+
+The Search results table and the Inferences page render **one Solr document per row**. The same logical
+triple — a subject related by a predicate to an object — appears as **several rows**, because a mapping's
+`id` UUID is hashed over the mapping set, the full subject/predicate/object slots, the predicate modifier,
+and the justification (`Mapping.generateMappingUuid()`). So the same triple yields distinct documents when
+it is asserted in more than one set, asserted under different justifications, or — since two-phase reasoning
+([ADR-0009](0009-two-phase-reasoning-owl-per-set-sssom-cross-set.md)) — asserted in a source set **and**
+re-derived as `SSSOM_INFERENCE` in the single cross-set inference set. The cross-set SSSOM set itself holds
+multiple same-SPO mappings. The net effect is that one relationship is scattered across rows, and the result
+count and paging are expressed in documents rather than in the relationships users actually care about.
+
+## Decision
+
+Collapse mappings that share the same **subject_id, predicate_id, predicate_modifier, and object_id** into a
+single **mapping group**, rendered as one expandable row whose members are reachable by expanding it.
+
+- **Group key — a denormalised `spo_key` field.** Add a single-valued, indexed, `docValues` string field
+  `spo_key` to `oxo2-mappings`, populated **once at dataload** as a deterministic hash of the four key
+  components. **IDs only** — labels and IRIs are excluded so the same entity collapses despite per-set label
+  drift; **`predicate_modifier` is included** so a relation and its negation (`predicate_modifier = Not`)
+  never collapse into one row. Mapping set, justification, and `inference_type` are deliberately *not* in the
+  key — they are exactly the axes being collapsed.
+- **Solr result grouping**, not Collapse+Expand. `group=true&group.field=spo_key&group.ngroups=true`
+  &`group.limit≈20`, so a single query returns each group's members **and** its true size.
+- **Grouping is presentation-layer, applied on top of every existing filter**, including the inference-type
+  filter ([ADR-0011](0011-inference-type-replaces-is-inferred.md)). A group's members are only the documents
+  passing the active filter; counts and badges reflect only what passed. A triple that is *only* OWL-inferred
+  does not appear while OWL is hidden.
+- **Representative = highest inference tier.** `group.sort=score desc` reuses the ADR-0011 boost
+  (`ASSERTED` > `SSSOM_INFERENCE` > `OWL_INFERENCE`, shorter chains first), so the parent row shows the
+  asserted member's subject/predicate/object when one exists. Groups themselves are ordered by the user's
+  column sort, with **`spo_key` appended as a final tiebreaker** so the order is total and paging is stable.
+- **Parent row** shows the representative's S/P/O, **stacked distinct inference-type badges** for the types
+  present, a member count, and **"Multiple"** where justification / provider / mapping set differ across
+  members. The expansion lists the members (up to `group.limit`); the count uses the group's true
+  `numFound`, and a **"+N more"** link deep-links to a flat Advanced view filtered to the triple when the cap
+  is exceeded.
+- **A page is N groups.** `rows`/`start` page over groups and `totalElements = getNGroups()`. Members are
+  transported on the representative as a `group_members` JSON string, mirroring the existing
+  `asserted_mappings` / `explanation` fields, so `FacetedMappingResponse` / `Page<Mapping>` keep their shape.
+- **Scope.** Grouping is intrinsic to the `NormalResultsTable`, which backs both the **Search** results and
+  the **Inferences** page. The **Advanced** tab stays flat (one document per row) as the per-document escape
+  hatch.
+
+## Consequences
+
+- Requires a new schema field and a **full reindex** to populate `spo_key`.
+- `group.ngroups` adds a modest query cost (exact distinct-group counting); acceptable for CURIE-scoped
+  searches, revisit only if a broad query is slow.
+- A mapping group is **identity-by-meaning**: positive and negated assertions of a triple remain distinct
+  rows because `predicate_modifier` is in the key.
+- The member list is capped at `group.limit`; the rare over-cap group shows an accurate total and a "+N more"
+  link rather than inlining every member.
+- Facet counts stay document-based, but the normal/inferences tables render no facets, so no `group.facet` is
+  needed.
+
+## Considered options
+
+- **Pure SPO key (no modifier)** — rejected: would collapse a relation with its negation into one row,
+  misrepresenting the data (see § predicate_modifier in `/CONTEXT.md`).
+- **Client-side per-page grouping** — rejected: same-SPO documents straddle page boundaries, and the total /
+  pagination counts would still be document-based.
+- **Collapsing QParser + ExpandComponent** — rejected: result grouping returns members and the group count in
+  one response, mapping directly onto the parent + expandable-children UI.
+- **Lazy-load members on expand** — deferred: inline-capped members keep the single-query `Page` shape;
+  revisit if groups turn out to be routinely huge.

--- a/oxo2-backend/CONTEXT.md
+++ b/oxo2-backend/CONTEXT.md
@@ -74,6 +74,19 @@ SSSOM 2 &gt; OWL 1) is multiplied by a distance factor bounded to `[1.0, 1.4]` (
 the 1.5× adjacent-tier ratio so it can never flip the tiers. See
 [ADR-0011](../docs/adr/0011-inference-type-replaces-is-inferred.md).
 
+#### Same-SPO grouping
+
+When the request sets `groupBySpo` (the normal/inferences result tables do; the Advanced tab does not),
+`SolrQueryBuilder` adds Solr result grouping on the `spo_key` field — `group=true`, `group.ngroups=true`,
+`group.limit`, `group.sort=score desc` (the representative is the highest inference-tier member, via the
+boost above), and `spo_key` is appended as the final sort key so paging is a stable total order. The page
+total becomes the **group count** (`getNGroups`), so a page is N triples not N documents. `OxOSolrClient`
+turns each group's top document into the representative row and attaches its members + true size as a
+`group_members` JSON string (`{"total":N,"members":[...]}`), serialised with the app `ObjectMapper`, leaving
+the `FacetedMappingResponse` / `Page<Mapping>` shape unchanged. Grouping sits on top of the filters, so a
+group's members reflect only what passed the inference-type filter. See
+[ADR-0013](../docs/adr/0013-group-same-spo-mappings-in-result-views.md).
+
 #### Column-filter matching
 
 `POST /api/v2/mappings/search` `columnFilters` use "contains" semantics. Label fields

--- a/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/controller/api/dto/request/MappingSearchRequest.java
+++ b/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/controller/api/dto/request/MappingSearchRequest.java
@@ -32,6 +32,10 @@ public class MappingSearchRequest {
     // boolean `inferred`.
     private List<InferenceType> inferenceType;
 
+    // Collapse same-SPO mappings into one row via Solr result grouping (ADR-0013). Default false;
+    // the normal/inferences result tables opt in, the Advanced tab stays flat.
+    private boolean groupBySpo = false;
+
 
     public List<String> getQueries() {
         return queries;
@@ -129,6 +133,14 @@ public class MappingSearchRequest {
         this.inferenceType = inferenceType;
     }
 
+    public boolean isGroupBySpo() {
+        return groupBySpo;
+    }
+
+    public void setGroupBySpo(boolean groupBySpo) {
+        this.groupBySpo = groupBySpo;
+    }
+
     @Override
     public String toString() {
         return "MappingSearchRequest{" +
@@ -144,6 +156,7 @@ public class MappingSearchRequest {
                 ", mappingSetIds=" + mappingSetIds +
                 ", advancedFieldQueries=" + advancedFieldQueries +
                 ", inferenceType=" + inferenceType +
+                ", groupBySpo=" + groupBySpo +
                 '}';
     }
 

--- a/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/OxOSolrClient.java
+++ b/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/OxOSolrClient.java
@@ -1,14 +1,22 @@
 package uk.ac.ebi.spot.oxo.backend.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.beans.DocumentObjectBinder;
 import org.apache.solr.client.solrj.impl.HttpJdkSolrClient;
 import org.apache.solr.client.solrj.response.FacetField;
+import org.apache.solr.client.solrj.response.Group;
+import org.apache.solr.client.solrj.response.GroupCommand;
+import org.apache.solr.client.solrj.response.GroupResponse;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -17,6 +25,7 @@ import org.springframework.stereotype.Service;
 import uk.ac.ebi.spot.oxo.backend.controller.api.dto.response.FacetedMappingResponse;
 import uk.ac.ebi.spot.oxo.model.sssom.Mapping;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +46,11 @@ public class OxOSolrClient {
 
     @Value("${socketTimeoutMillis}")
     private int socketTimeoutMillis;
+
+    // The app-configured Jackson mapper (Optionals unwrapped, same as response serialisation), used
+    // to build the group_members JSON string on a grouped query's representative (ADR-0013).
+    @Autowired
+    private ObjectMapper objectMapper;
 
     private static final Logger logger = LoggerFactory.getLogger(OxOSolrClient.class);
 
@@ -60,16 +74,54 @@ public class OxOSolrClient {
     public FacetedMappingResponse query(SolrParams params, Pageable pageable) throws Exception {
         QueryResponse response = solrMappingClient.query(params);
 
-        List<Mapping.Builder> mappingBuilders = response.getBeans(Mapping.Builder.class);
-        List<Mapping> mappings = mappingBuilders.stream()
-                .map(Mapping.Builder::build)
-                .collect(Collectors.toList());
-
-        Page<Mapping> mappingPage = new PageImpl<>(mappings, pageable, response.getResults().getNumFound());
+        GroupResponse groupResponse = response.getGroupResponse();
+        Page<Mapping> mappingPage = (groupResponse != null && !groupResponse.getValues().isEmpty())
+                ? buildGroupedPage(groupResponse.getValues().get(0), pageable)
+                : buildFlatPage(response, pageable);
 
         Map<String, Map<String, Long>> facetFieldToCounts = getFacetFieldToCounts(response);
 
         return new FacetedMappingResponse(mappingPage, facetFieldToCounts);
+    }
+
+    private Page<Mapping> buildFlatPage(QueryResponse response, Pageable pageable) {
+        List<Mapping> mappings = response.getBeans(Mapping.Builder.class).stream()
+                .map(Mapping.Builder::build)
+                .collect(Collectors.toList());
+        return new PageImpl<>(mappings, pageable, response.getResults().getNumFound());
+    }
+
+    /**
+     * Build a page of group representatives (ADR-0013). Each group's top document — the highest
+     * inference-tier member, via {@code group.sort=score} — becomes the representative row, carrying
+     * its members and true size as a group_members JSON string ({@code {"total":N,"members":[...]}}).
+     * The page total is the group count ({@code getNGroups}), so pagination counts triples, not
+     * documents.
+     */
+    private Page<Mapping> buildGroupedPage(GroupCommand command, Pageable pageable) throws Exception {
+        DocumentObjectBinder binder = solrMappingClient.getBinder();
+        List<Mapping> representatives = new ArrayList<>();
+        for (Group group : command.getValues()) {
+            SolrDocumentList memberDocs = group.getResult();
+            List<Mapping.Builder> builders = binder.getBeans(Mapping.Builder.class, memberDocs);
+            if (builders.isEmpty()) {
+                continue;
+            }
+            List<Mapping> members = builders.stream()
+                    .map(Mapping.Builder::build)
+                    .collect(Collectors.toList());
+            String groupMembers = serializeGroupMembers(members, memberDocs.getNumFound());
+            representatives.add(builders.get(0).groupMembersAsString(groupMembers).build());
+        }
+        int totalGroups = command.getNGroups() != null ? command.getNGroups() : representatives.size();
+        return new PageImpl<>(representatives, pageable, totalGroups);
+    }
+
+    private String serializeGroupMembers(List<Mapping> members, long total) throws Exception {
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("total", total);
+        root.set("members", objectMapper.valueToTree(members));
+        return objectMapper.writeValueAsString(root);
     }
 
     private static Map<String, Map<String, Long>> getFacetFieldToCounts(QueryResponse response) {

--- a/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrConstants.java
+++ b/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrConstants.java
@@ -8,4 +8,15 @@ public class SolrConstants {
     // ASSERTED is common (low idf) and SSSOM rare (high idf), so an additive bq would invert the
     // intended order.
     public final static String BOOST = "boost";
+
+    // Result grouping for same-SPO collapse (ADR-0013). group=true collapses documents sharing
+    // spo_key; group.ngroups makes the total a group count (a page is N groups); group.sort picks
+    // the representative (highest inference tier, via the score boost); group.limit caps the number
+    // of member documents returned per group.
+    public final static String GROUP = "group";
+    public final static String GROUP_FIELD = "group.field";
+    public final static String GROUP_NGROUPS = "group.ngroups";
+    public final static String GROUP_LIMIT = "group.limit";
+    public final static String GROUP_SORT = "group.sort";
+    public final static int GROUP_MEMBER_LIMIT = 20;
 }

--- a/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrQueryBuilder.java
+++ b/oxo2-backend/src/main/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrQueryBuilder.java
@@ -104,7 +104,29 @@ public class SolrQueryBuilder {
         solrQuery = configureFacets(solrQuery, mappingSearchRequest.getFacets());
         solrQuery = constructSortedFields(solrQuery, mappingSearchRequest);
 
+        if (mappingSearchRequest.isGroupBySpo()) {
+            applySpoGrouping(solrQuery);
+        }
+
         return solrQuery;
+    }
+
+    /**
+     * Same-SPO grouping (ADR-0013): collapse documents sharing {@code spo_key} into one
+     * representative row. {@code group.sort=score desc} makes the representative the highest
+     * inference-tier member (the {@link #RANKING_BOOST}); the main sort (set above) still orders the
+     * groups, and {@code spo_key} is appended as a total-order tiebreaker so paging is stable across
+     * requests. {@code group.ngroups} makes the result total a group count (a page is N groups), and
+     * {@code group.limit} caps the member documents inlined per group. Grouping sits on top of the
+     * existing filters, so a group's members reflect only what passed the inference-type filter.
+     */
+    private static void applySpoGrouping(SolrQuery solrQuery) {
+        solrQuery.set(SolrConstants.GROUP, true);
+        solrQuery.set(SolrConstants.GROUP_FIELD, MappingEnum.SPO_KEY.getField());
+        solrQuery.set(SolrConstants.GROUP_NGROUPS, true);
+        solrQuery.set(SolrConstants.GROUP_LIMIT, SolrConstants.GROUP_MEMBER_LIMIT);
+        solrQuery.set(SolrConstants.GROUP_SORT, "score desc");
+        solrQuery.addSort(MappingEnum.SPO_KEY.getField(), SolrQuery.ORDER.asc);
     }
 
 

--- a/oxo2-backend/src/test/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrQueryBuilderTest.java
+++ b/oxo2-backend/src/test/java/uk/ac/ebi/spot/oxo/backend/service/helper/SolrQueryBuilderTest.java
@@ -530,4 +530,40 @@ class SolrQueryBuilderTest {
                 // Distance factor bounded to [1.0, 1.4] so it can't invert the tier order.
                 .contains("sum(1,div(0.4,sum(def(distance,1),1)))");
     }
+
+    // ---------- same-SPO grouping (ADR-0013) ----------
+
+    @Test
+    void groupBySpoAddsGroupingParamsAndSpoKeyTiebreaker() {
+        MappingSearchRequest request = baseRequest();
+        request.setGroupBySpo(true);
+        SortedField sort = new SortedField();
+        sort.setId(MappingEnum.SUBJECT_LABEL);
+        sort.setDesc(false);
+        request.setSortedFields(List.of(sort));
+
+        SolrQuery solrQuery = SolrQueryBuilder.buildSolrQuery(request, PAGE_OF_TEN);
+
+        assertThat(solrQuery.get(SolrConstants.GROUP)).isEqualTo("true");
+        assertThat(solrQuery.get(SolrConstants.GROUP_FIELD)).isEqualTo(MappingEnum.SPO_KEY.getField());
+        assertThat(solrQuery.get(SolrConstants.GROUP_NGROUPS)).isEqualTo("true");
+        assertThat(solrQuery.get(SolrConstants.GROUP_SORT)).isEqualTo("score desc");
+        assertThat(solrQuery.get(SolrConstants.GROUP_LIMIT))
+                .isEqualTo(String.valueOf(SolrConstants.GROUP_MEMBER_LIMIT));
+        // spo_key is appended after the user's sort as a total-order tiebreaker for stable paging.
+        SolrQuery.SortClause lastSort = solrQuery.getSorts().get(solrQuery.getSorts().size() - 1);
+        assertThat(lastSort.getItem()).isEqualTo(MappingEnum.SPO_KEY.getField());
+        assertThat(lastSort.getOrder()).isEqualTo(SolrQuery.ORDER.asc);
+    }
+
+    @Test
+    void groupBySpoFalseAddsNoGroupingParams() {
+        MappingSearchRequest request = baseRequest();
+
+        SolrQuery solrQuery = SolrQueryBuilder.buildSolrQuery(request, PAGE_OF_TEN);
+
+        assertThat(solrQuery.get(SolrConstants.GROUP)).isNull();
+        assertThat(solrQuery.getSorts())
+                .noneMatch(clause -> clause.getItem().equals(MappingEnum.SPO_KEY.getField()));
+    }
 }

--- a/oxo2-dataload/CONTEXT.md
+++ b/oxo2-dataload/CONTEXT.md
@@ -111,6 +111,12 @@ them to `$SOLR_HOME` for local runs.
 > (the explanation step looks up asserted premises by it). An existing index must be rebuilt; a normal
 > `loadData.nextflow` run does a fresh load and so reindexes automatically.
 
+> **Reindex required (ADR-0013):** `oxo2-mappings` gained a `spo_key` field (the same-SPO grouping key:
+> a hash of subject_id + predicate_id + predicate_modifier + object_id). No pipeline code changed — it is
+> a derived `Mapping.spoKey()` accessor that every serialised mapping document (asserted and inferred)
+> carries automatically, so a normal `loadData.nextflow` run populates it. `stored="false"`, so it is never
+> returned in query results.
+
 ### Input validation
 
 Remote filenames sourced from registries (FTP listings, and TAR entries — including the GitHub archive

--- a/oxo2-dataload/solr-config/oxo2-mappings/conf/managed-schema.xml
+++ b/oxo2-dataload/solr-config/oxo2-mappings/conf/managed-schema.xml
@@ -526,6 +526,10 @@
   <field name="subject_label" type="text_general" multiValued="false" indexed="true" stored="true"/>
   <field name="subject_label_str" type="string" multiValued="false" indexed="true" stored="false"/>
   <field name="subject_label_ngram" type="text_ngram" multiValued="false" indexed="true" stored="false"/>
+  <!-- Grouping key for collapsing same-SPO mappings into one result-view row (ADR-0013): a hash of
+       subject_id + predicate_id + predicate_modifier + object_id. Derived at serialization time by
+       Mapping.spoKey(); docValues for grouping, not stored (never retrieved). -->
+  <field name="spo_key" type="string" multiValued="false" indexed="true" stored="false" docValues="true"/>
   <field name="subject_match_field" type="strings" multiValued="true" indexed="true" stored="true"/>
   <field name="subject_preprocessing" type="strings" multiValued="true" indexed="true" stored="true"/>
   <field name="subject_source" type="string" multiValued="false" indexed="true" stored="true"/>

--- a/oxo2-frontend/src/model/Mapping.ts
+++ b/oxo2-frontend/src/model/Mapping.ts
@@ -171,6 +171,9 @@ export interface MappingResponse {
     asserted_mappings?: string;
     explanation?: string;
     inference_type?: string;
+    // Result-view grouping (ADR-0013): on a grouped query the representative carries its group's
+    // members + true size as a JSON string {"total":N,"members":[...]}.
+    group_members?: string;
 }
 
 
@@ -232,4 +235,8 @@ export interface Mapping {
     subjectIdPrefix?: string;
     assertedMappings?: InferredMapping[];
     explanation?: InferredMapping | undefined
+    // Result-view grouping (ADR-0013): the underlying same-SPO mappings (including this
+    // representative) and the group's true total size. Absent on ungrouped rows.
+    groupMembers?: Mapping[];
+    groupSize?: number;
 }

--- a/oxo2-frontend/src/pages/results/MappingResultsSlice.ts
+++ b/oxo2-frontend/src/pages/results/MappingResultsSlice.ts
@@ -70,6 +70,8 @@ interface SearchRequest {
     // Multi-select inference-type filter (ADR-0011): omitted/empty = all types; otherwise restrict
     // to the listed codes (ASSERTED / OWL_INFERENCE / SSSOM_INFERENCE).
     inferenceType?: string[];
+    // Collapse same-SPO mappings into one row (ADR-0013). The normal/inferences result tables set this.
+    groupBySpo?: boolean;
 }
 
 export enum SearchStatus {
@@ -186,13 +188,25 @@ export function fromChainRuleResponse(chainRule: ChainRuleResponse ): ChainRule 
     return undefined;
 }
 
-export function fromJson(json: FacetedMappingResponse|undefined): FacetedMapping {
-    if (!json || !json.mappings || !json.mappings.content || !json.facets) {
-        return emptyFacetedMapping;
+// Parse a representative's group_members payload ({"total":N,"members":[...]}) into the member
+// Mapping[] and the group's true size (ADR-0013). Absent/blank → no grouping fields. Members carry no
+// group_members of their own, so fromMappingResponse does not recurse.
+export function fromGroupMembersString(groupMembersAsString?: string):
+    { groupMembers?: Mapping[]; groupSize?: number } {
+    if (!groupMembersAsString ||
+        (typeof groupMembersAsString === 'string' && groupMembersAsString.trim() === '')) {
+        return {};
     }
+    const parsed = JSON.parse(groupMembersAsString);
+    const members = Array.isArray(parsed?.members) ? parsed.members : [];
     return {
-        mappings: json.mappings.content.map(item => {
-            return {
+        groupMembers: members.map((member: MappingResponse) => fromMappingResponse(member)),
+        groupSize: typeof parsed?.total === 'number' ? parsed.total : members.length,
+    };
+}
+
+export function fromMappingResponse(item: MappingResponse): Mapping {
+    return {
                 authorId: item.author_id || '',
                 authorLabel: item.author_label || '',
                 comment: item.comment || '',
@@ -250,8 +264,16 @@ export function fromJson(json: FacetedMappingResponse|undefined): FacetedMapping
                 assertedMappings: fromAssertedMappingString(item.asserted_mappings),
                 explanation: fromExplanationString(item.explanation),
                 inferenceType: asInferenceType(item.inference_type),
-            };
-        }),
+                ...fromGroupMembersString(item.group_members),
+    };
+}
+
+export function fromJson(json: FacetedMappingResponse|undefined): FacetedMapping {
+    if (!json || !json.mappings || !json.mappings.content || !json.facets) {
+        return emptyFacetedMapping;
+    }
+    return {
+        mappings: json.mappings.content.map(fromMappingResponse),
         totalElements: json.mappings.totalElements,
         totalPages: json.mappings.totalPages,
         number: json.mappings.number,
@@ -263,7 +285,8 @@ export function fromJson(json: FacetedMappingResponse|undefined): FacetedMapping
 export function fetchMappings(queries: string[], page: number = 0, pageSize: number = 10, columnFilters: any[],
                               sorting: any[], mappingSetIds?: string[],
                               advancedFieldQueries?: AdvancedFieldQueryRequest[],
-                              inferenceType?: InferenceType[]): Promise<FacetedMappingResponse> {
+                              inferenceType?: InferenceType[],
+                              groupBySpo: boolean = false): Promise<FacetedMappingResponse> {
     const requestBody: SearchRequest = {
         queries: queries,
         page: page,
@@ -277,6 +300,7 @@ export function fetchMappings(queries: string[], page: number = 0, pageSize: num
         ...(mappingSetIds && mappingSetIds.length > 0 ? { mappingSetIds } : {}),
         ...(advancedFieldQueries && advancedFieldQueries.length > 0 ? { advancedFieldQueries } : {}),
         ...(inferenceType && inferenceType.length > 0 ? { inferenceType } : {}),
+        ...(groupBySpo ? { groupBySpo } : {}),
     };
 
     const searchResponse = post<SearchRequest, FacetedMappingResponse>(

--- a/oxo2-frontend/src/pages/results/NormalResultsTable.tsx
+++ b/oxo2-frontend/src/pages/results/NormalResultsTable.tsx
@@ -10,7 +10,7 @@ import {
     useMaterialReactTable,
 } from 'material-react-table';
 import {Mapping} from "../../model/Mapping.ts";
-import {InferenceType, DEFAULT_INFERENCE_TYPES} from "../../model/InferenceType";
+import {InferenceType, DEFAULT_INFERENCE_TYPES, INFERENCE_TYPE_ORDER, asInferenceType} from "../../model/InferenceType";
 import {InferenceTypeBadge} from "../../components/mapping/InferenceTypeBadge";
 import {InferenceTypeFilter} from "../../components/mapping/InferenceTypeFilter";
 import {IconButton, Tooltip} from "@mui/material";
@@ -56,10 +56,40 @@ const OBJECT_SORT_FIELDS: SortFieldDef[] = [
     {field: "object_iri", label: "IRI"},
 ];
 
+// Same-SPO grouping helpers (ADR-0013). A grouped representative carries all its members (including
+// itself) in groupMembers; an ungrouped row falls back to the single mapping.
+function groupMembersOf(mapping: Mapping): Mapping[] {
+    return mapping.groupMembers && mapping.groupMembers.length > 0 ? mapping.groupMembers : [mapping];
+}
+
+// Distinct inference types present in the group, in display order — for the stacked Type badges.
+function groupInferenceTypes(mapping: Mapping): InferenceType[] {
+    const members = groupMembersOf(mapping);
+    return INFERENCE_TYPE_ORDER.filter(type => members.some(member => asInferenceType(member.inferenceType) === type));
+}
+
+// The shared value of a per-mapping field across the group, or null when members differ ("Multiple").
+function sharedValue(mapping: Mapping, pick: (member: Mapping) => string | undefined): string | null {
+    const members = groupMembersOf(mapping);
+    const distinct = new Set(members.map(member => (pick(member) || '').trim()));
+    return distinct.size <= 1 ? (pick(mapping) || '') : null;
+}
+
+// Deep-link to the flat Advanced view filtered to this exact triple (the "+N more" overflow target).
+function advancedHrefForTriple(mapping: Mapping): string {
+    const params = new URLSearchParams();
+    params.append('af', `subject_id=${mapping.subjectId}`);
+    params.append('af', `predicate_id=${mapping.predicateId}`);
+    params.append('af', `object_id=${mapping.objectId}`);
+    return `/search/_advanced?${params.toString()}`;
+}
+
 /**
  * Default ("Search" tab) results: a compact, readable table of Subject / Predicate /
  * Object (each an id › label › IRI cell) plus mapping justification, provider, and
- * set. Field-level filtering is offered via per-column popovers; the Advanced tab
+ * set. Same-SPO mappings are collapsed into one expandable row (ADR-0013): the parent shows the
+ * representative triple with the distinct inference types and a member count, and the row expands to
+ * the underlying mappings. Field-level filtering is offered via per-column popovers; the Advanced tab
  * remains the home for exhaustive per-field filtering (see AdvancedResultsTable).
  */
 export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTypes = DEFAULT_INFERENCE_TYPES }:
@@ -140,7 +170,8 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
                 sorting,
                 mappingSetIds,
                 undefined,
-                inferenceTypes
+                inferenceTypes,
+                true // group same-SPO mappings into one row (ADR-0013)
             ),
         staleTime: Infinity,
     });
@@ -228,7 +259,12 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
                         />
                     </span>
                 ),
-                Cell: ({ row }) => <span className="break-all">{row.original.mappingJustification}</span>,
+                Cell: ({ row }) => {
+                    const shared = sharedValue(row.original, (member) => member.mappingJustification);
+                    return shared === null
+                        ? <span className="italic text-gray-500">Multiple</span>
+                        : <span className="break-all">{shared}</span>;
+                },
             },
             {
                 id: "inference_type",
@@ -236,7 +272,21 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
                 header: "Type",
                 enableSorting: false,
                 size: 130,
-                Cell: ({ row }) => <InferenceTypeBadge value={row.original.inferenceType} />,
+                Cell: ({ row }) => {
+                    const groupSize = row.original.groupSize ?? 1;
+                    return (
+                        <div className="flex flex-col gap-0.5">
+                            <div className="flex flex-wrap gap-1">
+                                {groupInferenceTypes(row.original).map((type) => (
+                                    <InferenceTypeBadge key={type} value={type} />
+                                ))}
+                            </div>
+                            {groupSize > 1 && (
+                                <span className="text-xs text-gray-500">{groupSize} mappings</span>
+                            )}
+                        </div>
+                    );
+                },
             },
             {
                 id: "mapping_provider",
@@ -254,7 +304,12 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
                         />
                     </span>
                 ),
-                Cell: ({ row }) => <span className="break-all">{row.original.mappingProvider}</span>,
+                Cell: ({ row }) => {
+                    const shared = sharedValue(row.original, (member) => member.mappingProvider);
+                    return shared === null
+                        ? <span className="italic text-gray-500">Multiple</span>
+                        : <span className="break-all">{shared}</span>;
+                },
             },
             {
                 id: "mapping_set",
@@ -262,17 +317,23 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
                 header: "Mapping set",
                 enableSorting: false,
                 size: 220,
-                Cell: ({ row }) => (
-                    <div className="flex flex-col gap-0.5 min-w-0">
-                        <span className="font-semibold break-words">{row.original.mappingSetTitle || "—"}</span>
-                        {row.original.mappingSetId && (
-                            <div className="flex items-start text-xs text-gray-500">
-                                <span className="break-all">{row.original.mappingSetId}</span>
-                                <CopyButton value={row.original.mappingSetId} title="Copy mapping set id" />
-                            </div>
-                        )}
-                    </div>
-                ),
+                Cell: ({ row }) => {
+                    // One row can span several sets; show "Multiple sets" rather than a misleading single set.
+                    if (sharedValue(row.original, (member) => member.mappingSetId) === null) {
+                        return <span className="italic text-gray-500">Multiple sets</span>;
+                    }
+                    return (
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                            <span className="font-semibold break-words">{row.original.mappingSetTitle || "—"}</span>
+                            {row.original.mappingSetId && (
+                                <div className="flex items-start text-xs text-gray-500">
+                                    <span className="break-all">{row.original.mappingSetId}</span>
+                                    <CopyButton value={row.original.mappingSetId} title="Copy mapping set id" />
+                                </div>
+                            )}
+                        </div>
+                    );
+                },
             },
         ],
         [handleFilterChange, handleSortChange]
@@ -289,6 +350,63 @@ export function NormalResultsTable({ queries, mappingSetIds, initialInferenceTyp
         enableDensityToggle: false,
         manualPagination: true,
         manualSorting: true,
+        // Same-SPO grouping (ADR-0013): only rows backing more than one mapping can expand; the detail
+        // panel lists the underlying members.
+        enableExpanding: true,
+        getRowCanExpand: (row) => (row.original.groupSize ?? 1) > 1,
+        renderDetailPanel: ({ row }) => {
+            const members = groupMembersOf(row.original);
+            const total = row.original.groupSize ?? members.length;
+            const overflow = total - members.length;
+            return (
+                <div className="px-4 py-2">
+                    <div className="text-sm font-medium mb-2">{total} mappings for this triple</div>
+                    <table className="w-full text-sm">
+                        <thead>
+                            <tr className="text-left text-gray-500">
+                                <th className="py-1 pr-4 font-medium">Type</th>
+                                <th className="py-1 pr-4 font-medium">Mapping justification</th>
+                                <th className="py-1 pr-4 font-medium">Mapping provider</th>
+                                <th className="py-1 pr-4 font-medium">Mapping set</th>
+                                <th className="py-1" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {members.map((member, index) => (
+                                <tr key={member.mappingId || index} className="border-t border-gray-200 align-top">
+                                    <td className="py-1 pr-4"><InferenceTypeBadge value={member.inferenceType} /></td>
+                                    <td className="py-1 pr-4 break-all">{member.mappingJustification}</td>
+                                    <td className="py-1 pr-4 break-all">{member.mappingProvider}</td>
+                                    <td className="py-1 pr-4">
+                                        <div className="font-semibold break-words">{member.mappingSetTitle || "—"}</div>
+                                        {member.mappingSetId && (
+                                            <div className="text-xs text-gray-500 break-all">{member.mappingSetId}</div>
+                                        )}
+                                    </td>
+                                    <td className="py-1">
+                                        <Tooltip title="View mapping details">
+                                            <IconButton
+                                                size="small"
+                                                onClick={() => navigate(`/mapping/${encodeURIComponent(member.mappingId)}`, { state: { mapping: member } })}
+                                            >
+                                                <EyeIcon className="h-4 w-4" />
+                                            </IconButton>
+                                        </Tooltip>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                    {overflow > 0 && (
+                        <div className="mt-2 text-sm">
+                            <a className="text-[#d4522c] hover:underline" href={advancedHrefForTriple(row.original)}>
+                                +{overflow} more — view all in Advanced search
+                            </a>
+                        </div>
+                    )}
+                </div>
+            );
+        },
         enableRowActions: true,
         positionActionsColumn: 'last',
         renderRowActions: ({ row }) => (

--- a/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/Mapping.java
+++ b/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/Mapping.java
@@ -172,6 +172,10 @@ public record Mapping (
         Optional<InferredMapping> explanation,
         @JsonProperty(EXPLANATION)
         Optional<String> explanationAsString,
+        // Result-view grouping (ADR-0013): on a grouped query the representative carries its group's
+        // members + true size as {"total":N,"members":[...]}; empty/absent otherwise.
+        @JsonProperty(GROUP_MEMBERS)
+        Optional<String> groupMembersAsString,
         @JsonProperty(MAPPING_ID)
         UUID mappingId,
         @JsonProperty(OBJECT_ID_PREFIX)
@@ -194,6 +198,28 @@ public record Mapping (
     @Override
     public int compareTo(Mapping o) {
         return this.mappingId.compareTo(o.mappingId);
+    }
+
+    /**
+     * Same-SPO grouping key (ADR-0013): a UUID hash of subject_id + predicate_id + predicate_modifier
+     * + object_id (IDs only — labels/IRIs vary across sets for the same entity; mapping set,
+     * justification and inference_type are the axes we collapse). predicate_modifier is included so a
+     * relation and its negation never share a key. Unit separators between components prevent
+     * ("ab","c") and ("a","bc") from colliding. Derived, not stored: emitted as the Solr
+     * {@code spo_key} field at dataload and present in API responses as a stable per-triple row key.
+     */
+    @JsonProperty(SPO_KEY)
+    public String spoKey() {
+        StringBuilder keyAsString = new StringBuilder();
+        subjectId.ifPresent(reference -> keyAsString.append(reference.getDataAsString()));
+        keyAsString.append('\u001f');
+        predicateId.ifPresent(reference -> keyAsString.append(reference.getDataAsString()));
+        keyAsString.append('\u001f');
+        predicateModifier.ifPresent(modifier -> keyAsString.append(modifier.value()));
+        keyAsString.append('\u001f');
+        objectId.ifPresent(reference -> keyAsString.append(reference.getDataAsString()));
+        byte[] bytes = keyAsString.toString().getBytes(StandardCharsets.UTF_8);
+        return UUID.nameUUIDFromBytes(bytes).toString();
     }
 
 
@@ -271,6 +297,7 @@ public record Mapping (
         private Optional<String> explanationAsString = Optional.empty();
         private List<InferredMapping> assertedMappings = new ArrayList<>();
         private Optional<String> assertedMappingsAsString = Optional.empty();
+        private Optional<String> groupMembersAsString = Optional.empty();
         private Optional<String> objectIdPrefix = Optional.empty();
         private Optional<Uri> objectIRI = Optional.empty();
         private Optional<String> predicateIdPrefix = Optional.empty();
@@ -1127,6 +1154,24 @@ public record Mapping (
             }
         }
 
+        // Result-view grouping (ADR-0013): the backend sets this on a grouped query's representative.
+        @JsonProperty(GROUP_MEMBERS)
+        public Builder groupMembersAsString(String groupMembersAsString) {
+            if (groupMembersAsString != null && !groupMembersAsString.isBlank())
+                this.groupMembersAsString = Optional.of(groupMembersAsString);
+            else
+                this.groupMembersAsString = Optional.empty();
+            return this;
+        }
+
+        // spo_key is a derived, output-only property (see Mapping#spoKey()). Accept and ignore it on
+        // input so deserialising a serialised Mapping — e.g. the dataload's own JSON, read back by the
+        // inference stage — doesn't fail on the extra field.
+        @JsonProperty(SPO_KEY)
+        public Builder spoKey(String ignoredSpoKey) {
+            return this;
+        }
+
         public Mapping build() {
             if (this.mappingId == null)
                 this.mappingId = generateMappingUuid();
@@ -1188,6 +1233,7 @@ public record Mapping (
                     inferenceType,
                     explanation,
                     explanationAsString,
+                    groupMembersAsString,
                     mappingId,
                     objectIdPrefix,
                     objectIRI,

--- a/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/MappingConstants.java
+++ b/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/MappingConstants.java
@@ -57,6 +57,10 @@ public class MappingConstants {
 
     // Extensions
     public static final String ASSERTED_MAPPINGS = "asserted_mappings";
+    // Result-view grouping (ADR-0013): spo_key is the same-SPO group key (derived, not deserialised);
+    // group_members carries a representative row's underlying members as {"total":N,"members":[...]}.
+    public static final String SPO_KEY = "spo_key";
+    public static final String GROUP_MEMBERS = "group_members";
     public static final String CHAIN_RULE = "chain_rule";
     public static final String CHAIN_RULE_APPLICATIONS = "chain_rule_applications";
     public static final String DISTANCE = "distance";

--- a/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/MappingEnum.java
+++ b/oxo2-shared/src/main/java/uk/ac/ebi/spot/oxo/model/sssom/MappingEnum.java
@@ -62,6 +62,7 @@ public enum MappingEnum {
 
     // Extensions to SSSOM
     ASSERTED_MAPPINGS(MappingConstants.ASSERTED_MAPPINGS),
+    SPO_KEY(MappingConstants.SPO_KEY),
     CHAIN_RULE(MappingConstants.CHAIN_RULE),
     CHAIN_RULE_APPLICATIONS(MappingConstants.CHAIN_RULE_APPLICATIONS),
     DISTANCE(MappingConstants.DISTANCE),

--- a/oxo2-shared/src/test/java/uk/ac/ebi/spot/oxo/model/sssom/MappingSpoKeyTest.java
+++ b/oxo2-shared/src/test/java/uk/ac/ebi/spot/oxo/model/sssom/MappingSpoKeyTest.java
@@ -1,0 +1,70 @@
+package uk.ac.ebi.spot.oxo.model.sssom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Same-SPO grouping key semantics (ADR-0013): spo_key collapses a triple across sets / justifications
+ * / inference types, keeps a relation distinct from its negation, and is a derived, output-only field.
+ */
+class MappingSpoKeyTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module());
+
+    private static Mapping.Builder triple(String subjectId, String predicateId, String objectId) {
+        return new Mapping.Builder()
+                .mappingSetId("https://example.org/set")
+                .subjectId(subjectId)
+                .predicateId(predicateId)
+                .objectId(objectId);
+    }
+
+    @Test
+    void spoKeyIsStableForTheSameTripleRegardlessOfSet() {
+        Mapping inSetA = triple("A:1", "skos:exactMatch", "B:2")
+                .mappingSetId("https://example.org/setA").build();
+        Mapping inSetB = triple("A:1", "skos:exactMatch", "B:2")
+                .mappingSetId("https://example.org/setB").build();
+        assertEquals(inSetA.spoKey(), inSetB.spoKey(),
+                "the same SPO triple must share a spo_key across mapping sets");
+        assertNotEquals(inSetA.mappingId(), inSetB.mappingId(),
+                "mapping_id still differs — the set is in the id hash, not the spo_key");
+    }
+
+    @Test
+    void predicateModifierSeparatesPositiveFromNegated() {
+        Mapping positive = triple("A:1", "skos:exactMatch", "B:2").build();
+        Mapping negated = triple("A:1", "skos:exactMatch", "B:2").predicateModifier("Not").build();
+        assertNotEquals(positive.spoKey(), negated.spoKey(),
+                "a relation and its negation must not collapse into one group");
+    }
+
+    @Test
+    void differentObjectsDoNotCollide() {
+        Mapping toB = triple("A:1", "skos:exactMatch", "B:2").build();
+        Mapping toC = triple("A:1", "skos:exactMatch", "B:3").build();
+        assertNotEquals(toB.spoKey(), toC.spoKey());
+    }
+
+    @Test
+    void spoKeyIsSerialisedAsTheSpoKeyField() throws Exception {
+        String json = objectMapper.writeValueAsString(triple("A:1", "skos:exactMatch", "B:2").build());
+        assertTrue(json.contains("\"spo_key\""), "serialised mapping must carry spo_key: " + json);
+    }
+
+    @Test
+    void builderIgnoresDerivedSpoKeyOnInput() {
+        // The derived, output-only spo_key must not break deserialisation through the builder.
+        Mapping mapping = assertDoesNotThrow(() -> triple("A:1", "skos:exactMatch", "B:2")
+                .spoKey("ignored-on-input")
+                .build());
+        assertFalse(mapping.spoKey().isBlank());
+    }
+}


### PR DESCRIPTION
Collapse mappings sharing (subject_id, predicate_id, predicate_modifier, object_id) into a single representative row, with the underlying mappings reachable on expansion. Implements ADR-0013.

- shared: derived Mapping.spoKey() emits the grouping key as a stored=false spo_key field on every serialised mapping (asserted + inferred); group_members transport string mirrors the asserted_mappings/explanation pattern.
- schema: new spo_key field on oxo2-mappings (requires reindex).
- backend: groupBySpo flag -> Solr result grouping (group.ngroups, group.sort= score for the representative, spo_key tiebreaker for stable paging); a page is N groups; OxOSolrClient attaches members + true size as group_members JSON.
- frontend: NormalResultsTable expandable rows (Search + Inferences tabs) with stacked type badges, member count, "Multiple" for differing columns, and a "+N more" overflow link; Advanced tab stays flat.
- docs: ADR-0013 plus CONTEXT.md (root, backend, dataload) updates.